### PR TITLE
build: install git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker
 
 # basics dependencies
-RUN apk add --no-cache -q curl bash npm nodejs
+RUN apk add --no-cache -q git curl bash npm nodejs
 
 # install `flyctl`
 RUN curl -sL https://fly.io/install.sh | sh


### PR DESCRIPTION
It's necessary since you can install a NPM dependency link git repo URL.